### PR TITLE
Escape HTML characters (e.g. < >) in Markdown output

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -7,6 +7,12 @@ require 'tempfile'
 module WordToMarkdownServer
   class App < Sinatra::Base
 
+    helpers do
+      def html_escape(text)
+        Rack::Utils.escape_html(text)
+      end
+    end
+
     use Rack::Coffee, root: 'public', urls: '/assets/javascripts'
 
     get "/" do

--- a/views/display.erb
+++ b/views/display.erb
@@ -4,7 +4,7 @@
   <div class="col-md-6">
     <h3>Markdown</h3>
     <div class="md-preview">
-      <pre><%= md %></pre>
+      <pre><%= html_escape md %></pre>
     </div>
   </div>
   <div class="col-md-6">


### PR DESCRIPTION
HTML characters were rendered correctly (i.e. escaped) in the HTML output on the right, but the Markdown output on the left didn't escape them. So some text like C++ templates (or static_casts) were not displayed correctly e.g. std::list&lt;int&gt; was output as std::list, with the "&lt;int&gt;" component omitted, as "int" is not a valid HTML tag.

This patch simply HTML escapes the rendered markdown using the method suggested in the the Sinatra FAQ - http://www.sinatrarb.com/faq.html#escape_html
