### PR TITLE
Add POST /md endpoint that returns just the markdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3-bullseye
+FROM ruby:3.1-bullseye
 
 ENV PORT=80
 ENV RACK_ENV=production

--- a/README.md
+++ b/README.md
@@ -4,22 +4,28 @@
 
 This project contains a lightweight server implementation of [word-to-markdown](https://github.com/benbalter/word-to-markdown) for converting Word Documents as a service.
 
-To run the server, simply run `script/server` and open `localhost:9292` in your browser. The server can also be run on Heroku.
+To run the server, simply run `script/server` and open <http://localhost:9292> in your browser. The server can also be run on Heroku.
 
 A live version runs at [word2md.com](https://word2md.com).
 
-You can also use it as a service by posting raw HTML to `/raw`, which will return the raw markdown in response.
+You can also use it as a service by posting raw HTML to `/raw`, which will return the raw markdown in response, or see `/md` endpoint below.
 
 ## Usage
 
 Visit [the site](https://word2md.com), run it locally, or deploy to Heroku.
 
+To use as an API to return Markdown, use `POST /md` endpoint and pass file as `doc` parameter:
+
+```plain
+curl http://localhost:9292/md -F "doc=@/full/path/to/file.docx"
+```
+
 ## Docker
 
 **NOTE:** When running Docker Windows Desktop make sure you are running the application in a Linux Container.
 
-```
+```plain
 docker build -t w2m .
-docker run -p 3000:3000 w2m
-open http://localhost:3000
+docker run -e PORT=9292 -p 9292:9292 w2m
+open http://localhost:9292
 ```

--- a/server.rb
+++ b/server.rb
@@ -108,6 +108,30 @@ module WordToMarkdownServer
       convert(file.path)
     end
 
+    post '/md' do
+      unless params['doc'] && params['doc'][:filename]
+        error = 'You must upload a document to convert.'
+        status 400
+        render_template :index, error: error, beta: !beta.nil?
+      end
+
+      unless /docx?$/i.match?(params['doc'][:filename])
+        error = 'It looks like you tried to upload something other than a Word Document.'
+        status 400
+        render_template :index, error: error, beta: !beta.nil?
+      end
+
+      md = if ENV.fetch('BETA_SERVER', nil) && params['beta']
+             convert_beta(params['doc'][:tempfile])
+           else
+             convert(params['doc'][:tempfile])
+           end
+
+      # return md as markdown text
+      content_type 'text/markdown'
+      md
+    end
+
     not_found do
       status 404
       'Not found'


### PR DESCRIPTION
An idea for a dedicated `POST /md` endpoint